### PR TITLE
Change css mjpage/mjpage_block definition order

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -152,19 +152,6 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
                 if (index > 0) {
                     // NOTE cf https://github.com/mathjax/MathJax-node/issues/283
                     if (typesetConfig.svg) result.css = `
-                            .mjpage__block {
-                            text-align: center;
-                            margin: 1em 0em;
-                            position: relative;
-                            display: block!important;
-                            text-indent: 0;
-                            max-width: none;
-                            max-height: none;
-                            min-width: 0;
-                            min-height: 0;
-                            width: 100%
-                            }
-
                             .mjpage .MJX-monospace {
                             font-family: monospace
                             }
@@ -223,6 +210,19 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
                             padding: 0;
                             border: 0;
                             margin: 0
+                            }
+														
+                            .mjpage__block {
+                            text-align: center;
+                            margin: 1em 0em;
+                            position: relative;
+                            display: block!important;
+                            text-indent: 0;
+                            max-width: none;
+                            max-height: none;
+                            min-width: 0;
+                            min-height: 0;
+                            width: 100%
                             }`;
                     if (result.css) {
                         // TODO make optional

--- a/test/displaymath_centered.js
+++ b/test/displaymath_centered.js
@@ -1,0 +1,17 @@
+const tape = require('tape');
+const mjpage = require('../lib/main.js').mjpage;
+const jsdom = require('jsdom').jsdom;
+
+tape('Display math gets centered', function(t) {
+    t.plan(1);
+    const input = '\\[ e^{i\\pi} = -1 \\]';
+    mjpage(input, {
+        format: ['TeX']
+    }, {
+        svg: true
+    }, function(output) {
+			const window = jsdom(output).defaultView
+			const style = window.getComputedStyle(window.document.querySelector('.mjpage'))
+      t.equal(style.textAlign, "center", 'Equation is centered');
+    });
+});


### PR DESCRIPTION
This allows to fix margin in displaymath. With current upstream, the margin property of ``mjpage_block`` is overwritten by the one from ``mjpage`` which appears after in the css.