### PR TITLE
Fix handling of format strings in custom script types

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -116,13 +116,15 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
 
     const normalizeFormat = function(str) {
         const format = str.toLowerCase();
-        if (format === "tex") {
+        if (format === "tex" || "inline-tex") {
             return "inline-TeX";
         } else if (format === "tex; mode=display") {
             return "TeX";
-        } else if (format == "mathml") {
+        } else if (format === "mathml") {
             return "MathML";
-        } else if (format == "asciimath") {
+        } else if (format === "mathml-block") {
+            return "MathML-block";
+        } else if (format === "asciimath") {
             return "AsciiMath";
         }
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -113,27 +113,32 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
         window.ascii.config.doc = document;
         window.ascii.PreProcess();
     }
-
-    const normalizeFormat = function(str) {
-        const format = str.toLowerCase();
-        if (format === "tex" || "inline-tex") {
-            return "inline-TeX";
-        } else if (format === "tex; mode=display") {
-            return "TeX";
-        } else if (format === "mathml") {
-            return "MathML";
-        } else if (format === "mathml-block") {
-            return "MathML-block";
-        } else if (format === "asciimath") {
-            return "AsciiMath";
-        }
-    }
-    // convert with mathjax-node
+    //normalize type strings
     const scripts = document.querySelectorAll('script[type^="math/"]');
+    for (let i = 0; i < scripts.length; i++) {
+        const script = scripts[i];
+        let format = script.getAttribute("type").toLowerCase().slice(5);
+        if (format === "tex" || "inline-tex") {
+            format = "math/inline-TeX";
+            // TODO Should use match to handle arbitrary spaces that are supported by MathJax
+            // https://github.com/mathjax/MathJax/blob/master/unpacked/jax/input/TeX/jax.js#L2168
+        } else if (format === "tex; mode=display") {
+            format = "math/TeX";
+        } else if (format === "mathml") {
+            format = "math/MathML";
+        } else if (format === "mathml-block") {
+            format = "math/MathML-block";
+        } else if (format === "asciimath") {
+            format = "math/AsciiMath";
+        }
+        script.setAttribute("type", format);
+    }
+
+    // convert with mathjax-node
     const process = function(index) {
         const script = scripts[index];
         if (script) {
-            const format = normalizeFormat(script.getAttribute('type').slice(5));
+            const format = script.getAttribute('type').slice(5);
             const conf = typesetConfig;
             conf.format = format;
             if (format === 'MathML-block') conf.format = 'MathML';

--- a/lib/main.js
+++ b/lib/main.js
@@ -118,7 +118,7 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
     for (let i = 0; i < scripts.length; i++) {
         const script = scripts[i];
         let format = script.getAttribute("type").toLowerCase().slice(5);
-        if (format === "tex" || "inline-tex") {
+        if (format === "tex" || format === "inline-tex") {
             format = "math/inline-TeX";
             // TODO Should use match to handle arbitrary spaces that are supported by MathJax
             // https://github.com/mathjax/MathJax/blob/master/unpacked/jax/input/TeX/jax.js#L2168

--- a/lib/main.js
+++ b/lib/main.js
@@ -118,11 +118,10 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
     for (let i = 0; i < scripts.length; i++) {
         const script = scripts[i];
         let format = script.getAttribute("type").toLowerCase().slice(5);
-        if (format === "tex" || format === "inline-tex") {
+        if (format === "inline-tex") {
             format = "math/inline-TeX";
-            // TODO Should use match to handle arbitrary spaces that are supported by MathJax
-            // https://github.com/mathjax/MathJax/blob/master/unpacked/jax/input/TeX/jax.js#L2168
-        } else if (format === "tex; mode=display") {
+            // via https://github.com/mathjax/MathJax/blob/master/unpacked/jax/input/TeX/jax.js#L2168
+        } else if (format.match(/tex((;|\s*|\n*)mode\s*=\s*display)?/i)) {
             format = "math/TeX";
         } else if (format === "mathml") {
             format = "math/MathML";
@@ -130,6 +129,9 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
             format = "math/MathML-block";
         } else if (format === "asciimath") {
             format = "math/AsciiMath";
+        } else {
+            console.log("Unknown format " + format);
+            continue;
         }
         script.setAttribute("type", format);
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -114,12 +114,24 @@ exports.mjpage = function(htmlstring, configOptions, typesetOptions, callback) {
         window.ascii.PreProcess();
     }
 
+    const normalizeFormat = function(str) {
+        const format = str.toLowerCase();
+        if (format === "tex") {
+            return "inline-TeX";
+        } else if (format === "tex; mode=display") {
+            return "TeX";
+        } else if (format == "mathml") {
+            return "MathML";
+        } else if (format == "asciimath") {
+            return "AsciiMath";
+        }
+    }
     // convert with mathjax-node
     const scripts = document.querySelectorAll('script[type^="math/"]');
     const process = function(index) {
         const script = scripts[index];
         if (script) {
-            const format = script.getAttribute('type').slice(5);
+            const format = normalizeFormat(script.getAttribute('type').slice(5));
             const conf = typesetConfig;
             conf.format = format;
             if (format === 'MathML-block') conf.format = 'MathML';

--- a/test/script-types.js
+++ b/test/script-types.js
@@ -1,0 +1,40 @@
+const tape = require('tape');
+const mjpage = require('../lib/main.js').mjpage;
+const jsdom = require('jsdom').jsdom;
+
+tape('Custom script types are processed correctly', function(t) {
+    t.plan(3);
+    const inlineInput = '<script type="math/tex"> e^{i\\pi} = -1</script>';
+    mjpage(inlineInput, {
+        format: ['TeX']
+    }, {
+        svg: true
+    }, function(output) {
+			const window = jsdom(output).defaultView
+			const style = window.getComputedStyle(window.document.querySelector('.mjpage'))
+      t.equal(style.textAlign, "left", '"math/tex" is left aligned');
+    });
+
+    const displayInput = '<script type="math/tex; mode=display"> e^{i\\pi} = -1</script>';
+    mjpage(displayInput, {
+        format: ['TeX']
+    }, {
+        svg: true
+    }, function(output) {
+			const window = jsdom(output).defaultView
+			const style = window.getComputedStyle(window.document.querySelector('.mjpage__block'))
+      t.equal(style.textAlign, "center", '"math/tex; mode=display" is center aligned');
+    });
+
+    const crazyCaseInput = '<script type="math/Tex   ;  modei  = display"> e^{i\\pi} = -1</script>';
+    mjpage(crazyCaseInput, {
+        format: ['TeX']
+    }, {
+        svg: true
+    }, function(output) {
+			const window = jsdom(output).defaultView
+			const style = window.getComputedStyle(window.document.querySelector('.mjpage__block'))
+      t.equal(style.textAlign, "center", 'Case and space insensitivity');
+    });
+
+});


### PR DESCRIPTION
This helps address #37 

1. Some tools output the "TeX" format as "tex", so normalize the type string.
2. Differentiate between "TeX", aka "inline-TeX", and "TeX; mode=display", aka "TeX".

I've tested it on the following webpage and it seems to prerender properly: https://williamjbowman.com/blog/2017/03/24/what-even-is-compiler-correctness/