### PR TITLE
Only create global cache element for SVG output

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -344,7 +344,7 @@ MjPageJob.prototype.run = function() {
                     styles.appendChild(document.createTextNode(result.css));
                     document.head.appendChild(styles);
                 }
-                if (typesetConfig.useGlobalCache) {
+                if (result.svg && typesetConfig.useGlobalCache) {
                     let globalSVG = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
                     globalSVG.style.display = 'none';
                     // TODO `globalSVG.appendChild(document.importNode(state.defs,true))` throws error


### PR DESCRIPTION
Fixes the part of #56 that is not an upstream issue.