### PR TITLE
Remove mutable parsedFormula object in conf.state passed to typeset()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -213,7 +213,6 @@ MjPageJob.prototype.run = function() {
             outputFormula: null,
             outputFormat: this.getOutputProperty(conf)
         };
-        conf.state.parsedFormula = parsedFormula; // for access from typeset callback
         this.emit("beforeConversion", parsedFormula);
 
         // create DOM wrapper
@@ -224,7 +223,6 @@ MjPageJob.prototype.run = function() {
 
         typeset(conf, (result, options) => {  // async call
             if(!options) console.error("typeset function did not return options object needed for state keeping");
-            let parsedFormula = options ? options.state.parsedFormula : result;
             if (result.errors) {
                 console.error(`Formula ${parsedFormula.sourceFormula} contains the following errors:\n`, result.errors);
                 this._outstandingHandlers--;


### PR DESCRIPTION
Hello, thank you for this great work!

Currently, there is a problem on `parsedFormula` in `afterConversion` event handler.
An example is below:

`sample.js`
```js
const { mjpage } = require('mathjax-node-page');

const html = `
  <html>
    <body>
      <span>Eq1: \`E = mc^2\$\`</span>
      <span>Eq2: \`F = ma\`</span>
    </body>
  </html>
`;

mjpage(html, {
  format: ['AsciiMath'],
}, {
  svg: true,
}, (result) => {
  // console.log(result);
})
.on('afterConversion', (parsedFormula) => {
  console.log(parsedFormula);
});
```

output:
```
{ id: 1,
  jobID: 0.8261754703685651,
  node: HTMLSpanElement {},
  sourceFormula: 'F = ma',
  sourceFormat: 'AsciiMath',
  outputFormula: 
   { speakText: 'E = mc^2$',
     css: ...,
     svg: ...,
     width: '10.396ex',
     height: '2.676ex',
     style: 'vertical-align: -0.338ex;' },
  outputFormat: 'svg' }
{ id: 1,
  jobID: 0.8261754703685651,
  node: HTMLSpanElement {},
  sourceFormula: 'F = ma',
  sourceFormat: 'AsciiMath',
  outputFormula: 
   { speakText: 'F = ma',
     css: ...,
     svg: ...,
     width: '8.367ex',
     height: '2.176ex',
     style: 'vertical-align: -0.338ex;' },
  outputFormat: 'svg' }
```

Different `parsedFormula` have same `id`, `jobId`, `sourceFormula`, ... though they have to be different.