### PR TITLE
Add passing input and result by jsdom object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ mathjax-node-page exports `mjpage` which expects four parameters:
 mjpage(input, mjpageConfig, mjnodeConfig, callback)
 ```
 
-Where `input` is a string with HTML, `pageConfig` specifies page-wide options, and `mjnodeConfig` expects mathjax-node configuration options.
+Where `input` is a string with HTML or `jsdom` object (`JSDOM` class should be acquired via exported `JSDOM`), `pageConfig` specifies page-wide options, and `mjnodeConfig` expects mathjax-node configuration options.
 
 The defaults for `pageConfig` are
 
@@ -35,7 +35,7 @@ The defaults for `pageConfig` are
     singleDollars: false, // allow single-dollar delimiter for inline TeX
     fragment: false, // return body.innerHTML instead of full document
     cssInline: true,  // determines whether inline css should be added
-    jsdom: {... }, // jsdom-related options
+    jsdom: {... }, // jsdom-related options (NOT used when passing jsdom object to mjpage())
     displayMessages: false, // determines whether Message.Set() calls are logged
     displayErrors: false, // determines whether error messages are shown on the console
     undefinedCharError: false, // determines whether unknown characters are saved in the error array
@@ -120,9 +120,10 @@ All formula conversion events pass `ParsedFormula` instance to the event handler
 ```
 
 #### Page conversion events
-* `beforeSerialiation` -> `handler(document, css`): runs when converted page DOM was prepared immediately before serialization. Use to manipulate resulting page DOM. The event handler receives `document` node (jsdom) and page `css`.
+* `beforeSerialiation` -> `handler(document, css`): runs when converted page DOM was prepared immediately before serialization. Use to manipulate resulting page DOM. The event handler receives `document` node (jsdom) and page `css`. Won't trigger if `input` is a `jsdom` object.
 
-`mjpage` function callback receives result after the DOM serialization.
+If `input` is a HTML string, `mjpage` function callback receives result after the DOM serialization.  
+If `input` is a `jsdom` object, `mjpage` function callback receives `jsdom` object itself.
 
 #### Example
 ```javascript

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,7 +29,7 @@ MjPageJob.prototype.constructor = MjPageJob;
 
 
 MjPageJob.prototype.run = function() {
-    const htmlstring = this.options.htmlstring,
+    const input = this.options.input,
       configOptions = this.options.configOptions,
       typesetOptions = this.options.typesetOptions,
       callback = this.callback;
@@ -46,6 +46,7 @@ MjPageJob.prototype.run = function() {
         cssInline: true,  // determines whether inline css should be added (leaving false still allows to add css as a separate file using beforeSerialization event hook)
         jsdom: {
             // NOTE these are not straight jsdom configuration options (cf. below)
+            // NOT used when passing jsdom object to mjpage()
             runScripts: 'outside-only', // set to "dangerously" to execute scripts from the HTML source
             virtualConsole: true
         },
@@ -114,7 +115,7 @@ MjPageJob.prototype.run = function() {
     }
 
     // set up DOM basics
-    const doc = new JSDOM(htmlstring, config.jsdom);
+    const doc = typeof input === 'string' ? new JSDOM(input, config.jsdom) : input;
     const window = doc.window;
     const document = window.document;
 
@@ -360,12 +361,17 @@ MjPageJob.prototype.run = function() {
             delete this._outstandingHandlers;
             _started = false;
 
-            this.emit('beforeSerialization', document, result.css);
-            let output = '';
-            if (config.fragment) output = document.body.innerHTML;
-            else output = doc.serialize();
-            window.close();
-            callback(output);
+            // return html string or jsdom object according to type of input
+            if (typeof input === 'string') {
+                this.emit('beforeSerialization', document, result.css);
+                let output = '';
+                if (config.fragment) output = document.body.innerHTML;
+                else output = doc.serialize();
+                window.close();
+                callback(output);
+            } else {
+                callback(doc);
+            }
 
             // prevent memory leaks
             this.removeAllListeners('beforeConversion')
@@ -429,19 +435,27 @@ exports.init = function (MjNode) {
 
 /**
  * Runs mathjax-node-page conversion.
- * @param htmlstring {string} - a string with HTML
+ * @param input {string} or {object} - a string with HTML or a JSDOM objecr
  * @param configOptions {object} - specifies page-wide options
  * @param typesetOptions {object} - expects mathjax-node configuration options
  * @param callback {function} - called with output result upon completion
  * @returns {MjPageJob} - returns job instance, which is event emitter
  */
-exports.mjpage = function (htmlstring, configOptions, typesetOptions, callback) {
+exports.mjpage = function (input, configOptions, typesetOptions, callback) {
+    if (typeof input !== 'string' && !(input instanceof JSDOM)) {
+        throw new TypeError(`input should be a string or instance of JSDOM (check your jsdom version?)`);
+    }
+
     // init on the first run
     if(!mathjax) {
         exports.init();
     }
 
-    let job = new MjPageJob(count++, {htmlstring, configOptions, typesetOptions}, callback);
+    let job = new MjPageJob(count++, {input, configOptions, typesetOptions}, callback);
     process.nextTick(() => job.run()); // need to run after returning the job to allow event handling
     return job;
 };
+
+// Pass different version of JSDOM to mjpage() could cause compatibility issues,
+// so let them use out version of JSDOM.
+exports.JSDOM = JSDOM;

--- a/test/pass-jsdom-object.js
+++ b/test/pass-jsdom-object.js
@@ -1,0 +1,23 @@
+const tape = require('tape');
+const { mjpage, JSDOM } = require('../lib/main.js');
+
+const input = '<span>\\mathrm{Menci}</span><script type="math/tex; mode=display">\\LaTeX</script>';
+
+tape('Passing input and result by jsdom object (issue 62)', function(t) {
+    t.plan(2);
+
+    const jsdom = new JSDOM(), document = jsdom.window.document;
+    document.body.innerHTML = input;
+    mjpage(jsdom, {
+        output: 'svg'
+    }, {}, function(output) {
+      t.ok(output === jsdom, 'Output exists, and IS the input jsdom object');
+
+      mjpage(input, {
+          output: 'svg'
+      }, {}, function(output) {
+          t.ok(output === document.documentElement.outerHTML,
+               'JSDOM and plain HTML input give the same output document');
+      })
+    });
+});


### PR DESCRIPTION
This PR enables developers to call `mjpage()` with a `jsdom` object, and receive result with the object itself -- no extra serialization/deserialization is required.

Notice that developers must use `JSDOM` class exported from this library, not installed by themselves. This is because different versions of JSDOM may cause compatibility issues and make it hard to check the argument's type.

When a `jsdom` object is passed to `mjpage()`, `configOptions.jsdom` will be ignored, `beforeSerialization` event won't be triggered, the `callback` will receive the passed `jsdom` object itself.

I've tested it in my project.

This will close #62.