### PR TITLE
Fix #76

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -223,11 +223,20 @@ MjPageJob.prototype.run = function() {
         script.parentNode.replaceChild(wrapper, script);
 
         typeset(conf, (result, options) => {  // async call
+            const checkFinished = () => {
+                // Since this call is async, decrease the counter of async operations to make sure all
+                // formulas are processed
+                this._outstandingHandlers--;
+                if (this._outstandingHandlers === 0) {
+                    this.emit('ready');
+                }
+            }
+
             if(!options) console.error("typeset function did not return options object needed for state keeping");
             let parsedFormula = options ? options.state.parsedFormula : result;
             if (result.errors) {
                 console.error(`Formula ${parsedFormula.sourceFormula} contains the following errors:\n`, result.errors);
-                this._outstandingHandlers--;
+                checkFinished();
                 return;
             }
 
@@ -243,13 +252,9 @@ MjPageJob.prototype.run = function() {
             parsedFormula.outputFormula = result;
             parsedFormula.node = wrapper;
             this._parsedFormulasCache.push(parsedFormula);
-            // Since this call is async, decrease the counter of async operations to make sure all formulas are processed
-            this._outstandingHandlers--;
 
             this.emit("afterConversion", parsedFormula);
-            if (this._outstandingHandlers === 0) {
-                this.emit('ready');
-            }
+            checkFinished();
         });
 
         this._outstandingHandlers++;

--- a/test/issue76.js
+++ b/test/issue76.js
@@ -1,0 +1,32 @@
+const tape = require('tape');
+const mjpage = require('../lib/main.js').mjpage;
+
+tape('Callback function should be called if last equation fails rendering', function(t) {
+    t.plan(2);
+
+    const input1 = `
+        $$\\Menci$$
+        $$\\mathrm{Menci}$$
+    `;
+    mjpage(input1, {}, {
+        svg: true
+    }, function(output) {
+        t.ok(true, 'Reached callback function when last equation succeeds');
+    });
+
+    const input2 = `
+        $$\\mathrm{Menci}$$
+        $$\\Menci$$
+    `;
+    let finished = false;
+    const timer = setTimeout(() => {
+        if (!finished) t.ok(false, 'Not reached callback function after 2000ms when last equation fails')
+    }, 2000);
+    mjpage(input2, {}, {
+        svg: true
+    }, function(output) {
+        if (finished) return;
+        clearTimeout(timer);
+        t.ok(true, 'Reached callback function when last equation fails');
+    });
+});


### PR DESCRIPTION
If a math fails rendering, the library won't check pending count and call callback. This PR fixes that.

I've moved the code to decrease and check pending count and call callback to a new function to avoid repeated code.

A test has been added to reproduce the bug and validate the fix.

Fixes #76